### PR TITLE
Rust: Locking and buffering of stdout of questionable effect

### DIFF
--- a/puzzlegen.rs
+++ b/puzzlegen.rs
@@ -34,8 +34,7 @@ use std::{fs, io, env, process};
         counts[count] += 3
     }
 
-    let stdout = io::stdout();
-    let mut sink = io::BufWriter::new(stdout.lock());
+    let mut stdout = io::stdout();
     for count in (0..(count + 1)).rev() {
         let seven = sevens[count];
         let (mut rest, mut bits) = (seven, [0u16;7]);
@@ -56,7 +55,7 @@ use std::{fs, io, env, process};
             out[place] = a + (25 - bits[place]) as u8
         }
         if any
-            { sink.write(&out).unwrap(); }
+            { stdout.write(&out).unwrap(); }
     }
 }
 #[cfg(not(main))] fn main() { rs_main(); }


### PR DESCRIPTION
Hi,

when having a look at the output of both programs, I noticed something curious: the C++ program and the Rust program have a different output behaviour, the C++ program having a much smoother output, while the Rust one "batches". (see: https://lobste.rs/s/oxuwzf/rust_vs_c_fine_grained_performance/comments/ygxpuc#c_ygxpuc)

The culprit there is the BufWriter around the `Stdout` handle. `std::io::Stdout` is already linebuffered, so the additional Buffer seems questionable, as it only forwards.

Locking the stream also has no effect, as it only makes sure the lock holder is the only one currently accessing the buffer. As this is a single-threaded program, I don't see the cited _performance improvement_.

After removing both, a) the output is smoother, b) I found no noticeable difference in the benchmarks.

Best,
Florian

P.S.: Although you may find it cumbersome that you have bind stdin, here's an explanation on why it makes sense given the lifetime system of Rust. It may seem cumbersome, but it help reasoning: https://lobste.rs/s/oxuwzf/rust_vs_c_fine_grained_performance/comments/0bhl8y#c_0bhl8y
